### PR TITLE
Explain selecting stream directionality

### DIFF
--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -686,7 +686,8 @@ WT_STREAM Capsule {
 WT_STREAM capsules contain the following fields:
 
 Stream ID:
-: The stream ID for the stream.
+: The stream ID for the stream.  Its second least significant bit indicates whether
+  the stream is bidirectional or unidirectional, as describe in {{webtransport-streams}}.
 
 Stream Data:
 : Zero or more bytes of data for the stream.  Empty WT_STREAM capsules MUST NOT

--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -686,7 +686,7 @@ WT_STREAM Capsule {
 WT_STREAM capsules contain the following fields:
 
 Stream ID:
-: The stream ID for the stream.  Its second least significant bit indicates whether
+: The stream ID for the stream.  The second least significant bit of the Stream ID indicates whether
   the stream is bidirectional or unidirectional, as described in {{webtransport-streams}}.
 
 Stream Data:

--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -687,7 +687,7 @@ WT_STREAM capsules contain the following fields:
 
 Stream ID:
 : The stream ID for the stream.  Its second least significant bit indicates whether
-  the stream is bidirectional or unidirectional, as describe in {{webtransport-streams}}.
+  the stream is bidirectional or unidirectional, as described in {{webtransport-streams}}.
 
 Stream Data:
 : Zero or more bytes of data for the stream.  Empty WT_STREAM capsules MUST NOT


### PR DESCRIPTION
After reading the document, I was left wondering how the directionality of a new streams is communicated. I believe that this is done by selecting a stream ID with the corresponding second least significant bit. If that's the case, I think the description for the WT_STREAM capsule could be expanded.